### PR TITLE
Move disabling progressbar to s2i assemble script

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -8,6 +8,9 @@ pushd /tmp/src
 
 THOTH_DRY_RUN=${THOTH_DRY_RUN:-0}
 THOTH_ADVISE=${THOTH_ADVISE:-1}
+THOTH_HOST=${THOTH_HOST:"khemenu.thoth-station.ninja"}
+# Disable progressbar for thamos.
+THAMOS_NO_PROGRESSBAR=${THAMOS_NO_PROGRESSBAR:-1}
 
 [[ ${THOTH_DRY_RUN} -ne 0 && ${THOTH_ADVISE} -ne 0 ]] && {
   echo "Cannot use THOTH_DRY_RUN and THOTH_ADVISE configuration options at the same time" >&2

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -61,14 +61,11 @@ objects:
               value: "1"
             # Force use Thoth service - do not use Pipfile.lock present in the Git repo.
             - name: "THOTH_ADVISE"
-              value: "1"
+              value: "0"
             # Set to 1 if you would like to submit stack to Thoth but not use
             # the recommended stack - Pipfile.lock from the Git repo will be
             # used.
             - name: "THOTH_DRY_RUN"
-              value: "0"
-            # Disable progressbar for thamos.
-            - name: "THAMOS_NO_PROGRESSBAR"
               value: "1"
             # .thoth.yaml file is generated from template file
             # thoth_conf_template.yaml


### PR DESCRIPTION
There is no need to have it configurable directly from the template.